### PR TITLE
Update resource_ou_cloud_access_role.go

### DIFF
--- a/kion/resource_ou_cloud_access_role.go
+++ b/kion/resource_ou_cloud_access_role.go
@@ -57,6 +57,18 @@ func resourceOUCloudAccessRole() *schema.Resource {
 				Required: true,
 				ForceNew: true, // Not allowed to be changed, forces new item if changed.
 			},
+			"azure_role_definitions": {
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+					},
+				},
+				Type:     schema.TypeSet,
+				Optional: true,
+			},
 			"long_term_access_keys": {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -115,6 +127,7 @@ func resourceOUCloudAccessRoleCreate(ctx context.Context, d *schema.ResourceData
 		AwsIamPermissionsBoundary: hc.FlattenIntPointer(d, "aws_iam_permissions_boundary"),
 		AwsIamPolicies:            hc.FlattenGenericIDPointer(d, "aws_iam_policies"),
 		AwsIamRoleName:            d.Get("aws_iam_role_name").(string),
+		AzureRoleDefinitions:      hc.FlattenGenericIDPointer(d, "azure_role_definitions"),
 		LongTermAccessKeys:        d.Get("long_term_access_keys").(bool),
 		Name:                      d.Get("name").(string),
 		OUID:                      d.Get("ou_id").(int),
@@ -174,6 +187,9 @@ func resourceOUCloudAccessRoleRead(ctx context.Context, d *schema.ResourceData, 
 		data["aws_iam_policies"] = hc.InflateObjectWithID(item.AwsIamPolicies)
 	}
 	data["aws_iam_role_name"] = item.OUCloudAccessRole.AwsIamRoleName
+	if hc.InflateObjectWithID(item.AzureRoleDefinitions) != nil {
+		data["azure_role_definitions"] = hc.InflateObjectWithID(item.AzureRoleDefinitions)
+	}
 	data["long_term_access_keys"] = item.OUCloudAccessRole.LongTermAccessKeys
 	data["name"] = item.OUCloudAccessRole.Name
 	data["ou_id"] = item.OUCloudAccessRole.OUID
@@ -237,11 +253,13 @@ func resourceOUCloudAccessRoleUpdate(ctx context.Context, d *schema.ResourceData
 	// Handle associations.
 	if d.HasChanges("aws_iam_permissions_boundary",
 		"aws_iam_policies",
+		"azure_role_definitions",
 		"user_groups",
 		"users") {
 		hasChanged++
 		arrAddAwsIamPermissionsBoundary, arrRemoveAwsIamPermissionsBoundary, _, _ := hc.AssociationChangedInt(d, "aws_iam_permissions_boundary")
 		arrAddAwsIamPolicies, arrRemoveAwsIamPolicies, _, _ := hc.AssociationChanged(d, "aws_iam_policies")
+		arrAddAzureRoleDefinitions, arrRemoveAzureRoleDefinitions, _, _ := hc.AssociationChanged(d, "azure_role_definitions")
 		arrAddUserGroupIds, arrRemoveUserGroupIds, _, _ := hc.AssociationChanged(d, "user_groups")
 		arrAddUserIds, arrRemoveUserIds, _, _ := hc.AssociationChanged(d, "users")
 
@@ -252,6 +270,7 @@ func resourceOUCloudAccessRoleUpdate(ctx context.Context, d *schema.ResourceData
 			_, err := c.POST(fmt.Sprintf("/v3/ou-cloud-access-role/%s/association", ID), hc.OUCloudAccessRoleAssociationsAdd{
 				AwsIamPermissionsBoundary: arrAddAwsIamPermissionsBoundary,
 				AwsIamPolicies:            &arrAddAwsIamPolicies,
+				AzureRoleDefinitions:      &arrAddAzureRoleDefinitions,
 				UserGroupIds:              &arrAddUserGroupIds,
 				UserIds:                   &arrAddUserIds,
 			})
@@ -267,11 +286,13 @@ func resourceOUCloudAccessRoleUpdate(ctx context.Context, d *schema.ResourceData
 
 		if arrRemoveAwsIamPermissionsBoundary != nil ||
 			len(arrRemoveAwsIamPolicies) > 0 ||
+			len(arrRemoveAzureRoleDefinitions) > 0 ||
 			len(arrRemoveUserGroupIds) > 0 ||
 			len(arrRemoveUserIds) > 0 {
 			err := c.DELETE(fmt.Sprintf("/v3/ou-cloud-access-role/%s/association", ID), hc.OUCloudAccessRoleAssociationsRemove{
 				AwsIamPermissionsBoundary: arrRemoveAwsIamPermissionsBoundary,
 				AwsIamPolicies:            &arrRemoveAwsIamPolicies,
+				AzureRoleDefinitions:      &arrRemoveAzureRoleDefinitions,
 				UserGroupIds:              &arrRemoveUserGroupIds,
 				UserIds:                   &arrRemoveUserIds,
 			})


### PR DESCRIPTION
Added missing `azure_role_definitions` field to `resource_ou_cloud_access_role.go,` based off of Swagger information about the API endpoint `/v3/ou-cloud-access-role` and the existing feature for `resource_project_cloud_access_role.go`.