### PR TITLE
Create named type for AzurePolicy and add required attributes to reso…

### DIFF
--- a/kion/internal/kionclient/models_azure_policy.go
+++ b/kion/internal/kionclient/models_azure_policy.go
@@ -36,16 +36,19 @@ type AzurePolicyResponse struct {
 	Status int `json:"status"`
 }
 
+// AzurePolicy for AzurePolicyCreate
+type AzurePolicy struct {
+	Description string `json:"description"`
+	Name        string `json:"name"`
+	Parameters  string `json:"parameters"`
+	Policy      string `json:"policy"`
+}
+
 // AzurePolicyCreate for: POST /api/v3/azure-policy
 type AzurePolicyCreate struct {
-	AzurePolicy struct {
-		Description string `json:"description"`
-		Name        string `json:"name"`
-		Parameters  string `json:"parameters"`
-		Policy      string `json:"policy"`
-	} `json:"azure_policy"`
-	OwnerUserGroups *[]int `json:"owner_user_groups"`
-	OwnerUsers      *[]int `json:"owner_users"`
+	AzurePolicy     AzurePolicy `json:"azure_policy"`
+	OwnerUserGroups *[]int      `json:"owner_user_groups"`
+	OwnerUsers      *[]int      `json:"owner_users"`
 }
 
 // AzurePolicyDefinitionUpdate for: PATCH /api/v3/azure-policy/{id}

--- a/kion/resource_azure_policy.go
+++ b/kion/resource_azure_policy.go
@@ -92,6 +92,12 @@ func resourceAzurePolicyCreate(ctx context.Context, d *schema.ResourceData, m in
 	client := m.(*hc.Client)
 
 	post := hc.AzurePolicyCreate{
+        AzurePolicy: hc.AzurePolicy{
+			Description: d.Get("description").(string),
+			Name:        d.Get("name").(string),
+			Parameters:  d.Get("parameters").(string),
+			Policy:      d.Get("policy").(string),
+		},
 		OwnerUserGroups: hc.FlattenGenericIDPointer(d, "owner_user_groups"),
 		OwnerUsers:      hc.FlattenGenericIDPointer(d, "owner_users"),
 	}


### PR DESCRIPTION
Addressed a type definition issue that prevented successful Azure Policy creation. Introduced a named struct for AzurePolicy within the AzurePolicyCreate struct to allow nested structs in the POST definition to ensure compatibility with the Kion API's required attributes.